### PR TITLE
removed unecessary init() method call

### DIFF
--- a/Open-Rest/src/main/java/app/open/software/rest/WebServer.java
+++ b/Open-Rest/src/main/java/app/open/software/rest/WebServer.java
@@ -65,8 +65,6 @@ public class WebServer {
 		before("/*", auth);
 
 		this.versions.forEach(RestVersion::init);
-
-		init();
 	}
 
 	/**


### PR DESCRIPTION
The init method is already called when creating routes, so it doesn't really affect much.